### PR TITLE
Fixed a few minor bugs

### DIFF
--- a/PRORWTS2.S
+++ b/PRORWTS2.S
@@ -403,7 +403,7 @@ adjpath         tya
                 bne     -
                 ldy     #$ff
                 lda     (bloklo), y
-                bne     -             ;This is always $00, so it does not work with beq. Am I right?
+                beq     - 
 
 set_slot        stx     slot + 2
 !if allow_extend = 1 {

--- a/PRORWTS2.S
+++ b/PRORWTS2.S
@@ -274,11 +274,11 @@ init            jsr     SETKBD
                 ldx     $200
                 dex
                 stx     sizelo
-                bmi     +++
 
                 ;find current directory name in directory
 
                 sec
+                bmi     +++   ; When enable_floppy = 1, it moves because it exceeds the range
                 php
 
 readblock       jsr     MLI
@@ -403,7 +403,7 @@ adjpath         tya
                 bne     -
                 ldy     #$ff
                 lda     (bloklo), y
-                beq     -
+                bne     -             ;This is always $00, so it does not work with beq. Am I right?
 
 set_slot        stx     slot + 2
 !if allow_extend = 1 {
@@ -1599,7 +1599,7 @@ cmpsecrd        jsr     readadr
 
                 jsr     readd5aa
                 eor     #$ad ;zero A if match
-                bne     cmdsecrd
+                bne     cmpsecrd
 unrread4 = unrelocdsk + (* - reloc)
 -               ldx     Q6L
                 bpl     -


### PR DESCRIPTION
While porting prorwts2 to cc65, I found some minor bugs. Occurs when enable_floppy = 1. prorwts2 is really cool. Thank you.